### PR TITLE
[STEP 2] Add LangChain4j 1.10.0 dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,19 @@ repositories {
 }
 
 dependencies {
+	implementation platform("dev.langchain4j:langchain4j-bom:1.10.0")
+
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework:spring-webflux'
 
+	implementation 'dev.langchain4j:langchain4j'
+	implementation 'dev.langchain4j:langchain4j-anthropic'
+	implementation 'dev.langchain4j:langchain4j-http-client-jdk'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.mockito:mockito-core:5.12.0'
+	testImplementation 'io.projectreactor:reactor-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 


### PR DESCRIPTION
Add the LangChain4j BOM and required dependencies for Anthropic, JDK HTTP client, and testing.

Acceptance Criteria
- LangChain4j BOM 1.10.0 added
- Anthropic module added
- JDK HTTP client module added
- Test dependencies added
- ./gradlew clean test passes

Closes #8 