### PR TITLE
[STEP 5] Implement MCP HTTP client

### DIFF
--- a/src/main/java/com/anis/agent/mcp/McpHttpClient.java
+++ b/src/main/java/com/anis/agent/mcp/McpHttpClient.java
@@ -1,0 +1,58 @@
+package com.anis.agent.mcp;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import reactor.core.publisher.Mono;
+
+@Component
+public class McpHttpClient {
+
+    private final WebClient webClient;
+    private final String mcpPath;
+
+    public McpHttpClient(
+            WebClient.Builder webClientBuilder,
+            @Value("${mcp.base-url}") String baseUrl,
+            @Value("${mcp.path}") String mcpPath
+    ) {
+        this.webClient = webClientBuilder.baseUrl(baseUrl).build();
+        this.mcpPath = mcpPath;
+    }
+
+    public Mono<Map> listTools() {
+        Map<String, Object> body = Map.of(
+                "jsonrpc", "2.0",
+                "id", "1",
+                "method", "tools/list",
+                "params", Map.of()
+        );
+
+        return webClient.post()
+                .uri(mcpPath)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(Map.class);
+    }
+
+    public Mono<Map> callTool(String toolName, Map<String, Object> arguments) {
+        Map<String, Object> body = Map.of(
+                "jsonrpc", "2.0",
+                "id", "1",
+                "method", "tools/call",
+                "params", Map.of(
+                        "name", toolName,
+                        "arguments", arguments
+                )
+        );
+
+        return webClient.post()
+                .uri(mcpPath)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(Map.class);
+    }
+}


### PR DESCRIPTION
Implement the MCP HTTP client used to communicate with the MCP wrapper through JSON-RPC over HTTP.

Implementation includes:
- McpHttpClient component
- tools/list support
- tools/call support
- WebClient integration using mcp.base-url and mcp.path

Acceptance Criteria
- McpHttpClient created
- MCP endpoint built from configuration
- tools/list supported
- tools/call supported
- Project builds successfully

Closes #14 