### PR TITLE
[STEP 6] Bridge MCP tools with LangChain4j

### DIFF
--- a/src/main/java/com/anis/agent/agent/BacklogAgent.java
+++ b/src/main/java/com/anis/agent/agent/BacklogAgent.java
@@ -8,7 +8,7 @@ public interface BacklogAgent {
     @SystemMessage("""
         You are a backlog assistant.
         You help generate clear GitHub issues and backlog tasks.
-        Always produce structured and concise outputs.
+        When a user asks to create a GitHub task or issue, you must call the appropriate tool.
         Never expose secrets or environment variables.
         """)
     String handle(@UserMessage String message);

--- a/src/main/java/com/anis/agent/config/LangChainConfig.java
+++ b/src/main/java/com/anis/agent/config/LangChainConfig.java
@@ -1,12 +1,14 @@
 package com.anis.agent.config;
 
 import java.time.Duration;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.anis.agent.agent.BacklogAgent;
+import com.anis.agent.tools.AgentTool;
 
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.service.AiServices;
@@ -28,9 +30,10 @@ public class LangChainConfig {
     }
 
     @Bean
-    BacklogAgent backlogAgent(AnthropicChatModel chatModel) {
+    BacklogAgent backlogAgent(AnthropicChatModel chatModel, List<AgentTool> tools) {
         return AiServices.builder(BacklogAgent.class)
                 .chatModel(chatModel)
+                .tools(tools.toArray())
                 .build();
     }
 }

--- a/src/main/java/com/anis/agent/tools/AgentTool.java
+++ b/src/main/java/com/anis/agent/tools/AgentTool.java
@@ -1,0 +1,4 @@
+package com.anis.agent.tools;
+
+public interface AgentTool {
+}

--- a/src/main/java/com/anis/agent/tools/github/GitHubMcpTools.java
+++ b/src/main/java/com/anis/agent/tools/github/GitHubMcpTools.java
@@ -1,0 +1,44 @@
+package com.anis.agent.tools.github;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.anis.agent.mcp.McpHttpClient;
+import com.anis.agent.tools.AgentTool;
+
+import dev.langchain4j.agent.tool.Tool;
+
+@Component
+public class GitHubMcpTools implements AgentTool {
+
+    private final McpHttpClient mcp;
+    private final String owner;
+    private final String repo;
+
+    public GitHubMcpTools(
+            McpHttpClient mcp,
+            @Value("${github.owner}") String owner,
+            @Value("${github.repo}") String repo
+    ) {
+        this.mcp = mcp;
+        this.owner = owner;
+        this.repo = repo;
+    }
+
+    @Tool("Create a GitHub issue in the configured repository")
+    public String createIssue(String title, String body) {
+        Map<String, Object> result = mcp.callTool(
+                "create_issue",
+                Map.of(
+                        "owner", owner,
+                        "repo", repo,
+                        "title", title,
+                        "body", body
+                )
+        ).block();
+
+        return "Issue created successfully: " + result;
+    }
+}


### PR DESCRIPTION
Bridge MCP tools with LangChain4j so the agent can create GitHub issues.

Implementation includes:
- AgentTool marker interface
- GitHubMcpTools component
- createIssue tool method calling MCP create_issue
- LangChainConfig updated to register tools in AiServices

Acceptance Criteria
- AgentTool created
- GitHubMcpTools created
- createIssue tool implemented
- MCP create_issue called through McpHttpClient
- Project builds successfully

Closes #16 