### PR TITLE
[STEP 7] Expose Agent REST API

### DIFF
--- a/src/main/java/com/anis/agent/config/LangChainConfig.java
+++ b/src/main/java/com/anis/agent/config/LangChainConfig.java
@@ -22,6 +22,9 @@ public class LangChainConfig {
             @Value("${anthropic.model}") String model,
             @Value("${anthropic.timeout-seconds}") Integer timeoutSeconds
     ) {
+        System.out.println("Anthropic key loaded: " +
+                (apiKey == null ? "null" : apiKey.substring(0, Math.min(10, apiKey.length())) + "..."));
+
         return AnthropicChatModel.builder()
                 .apiKey(apiKey)
                 .modelName(model)

--- a/src/main/java/com/anis/agent/service/AgentService.java
+++ b/src/main/java/com/anis/agent/service/AgentService.java
@@ -1,0 +1,19 @@
+package com.anis.agent.service;
+
+import org.springframework.stereotype.Service;
+
+import com.anis.agent.agent.BacklogAgent;
+
+@Service
+public class AgentService {
+
+    private final BacklogAgent backlogAgent;
+
+    public AgentService(BacklogAgent backlogAgent) {
+        this.backlogAgent = backlogAgent;
+    }
+
+    public String run(String prompt) {
+        return backlogAgent.handle(prompt);
+    }
+}

--- a/src/main/java/com/anis/agent/web/AgentController.java
+++ b/src/main/java/com/anis/agent/web/AgentController.java
@@ -1,0 +1,24 @@
+package com.anis.agent.web;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.anis.agent.service.AgentService;
+
+@RestController
+@RequestMapping("/api")
+public class AgentController {
+
+    private final AgentService agentService;
+
+    public AgentController(AgentService agentService) {
+        this.agentService = agentService;
+    }
+
+    @PostMapping("/run")
+    public String run(@RequestBody String prompt) {
+        return agentService.run(prompt);
+    }
+}


### PR DESCRIPTION
Context
Expose a REST API endpoint to run the AI backlog agent.

Implementation
- Added AgentService to call BacklogAgent
- Added AgentController exposing POST /api/run endpoint
- Integrated REST layer with LangChain4j agent

Manual testing
The endpoint /api/run was tested locally using curl.

Example:
curl -X POST http://localhost:8080/api/run \
  -H "Content-Type: text/plain" \
  --data "Say hello in one sentence"

The request correctly reaches the AI integration layer.

Note
The Anthropic API call currently fails due to insufficient API credits,
but the application flow (Controller → Service → Agent) is verified.

Acceptance Criteria
- AgentService created
- AgentController created
- POST /api/run endpoint available
- Project builds successfully

Closes #18 