### PR TITLE
[STEP 11] Setup CI/CD with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,25 +2,32 @@ name: CI
 
 on:
   push:
-    branches: [ "**" ]
+    branches:
+      - "**"
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
 
 jobs:
-  build-test:
+  build-and-test:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
 
-      - name: Setup JDK 21
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: '21'
           cache: gradle
 
-      - name: Grant execute permission
+      - name: Make Gradle wrapper executable
         run: chmod +x gradlew
 
-      - name: Build & Test
+      - name: Build and test
         run: ./gradlew --no-daemon clean test
+
+      - name: Build Docker image
+        run: docker build -t local/ai-agent:ci .

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,36 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/anisdali/lab_mcp_ai_agent_springboot:latest
+            ghcr.io/anisdali/lab_mcp_ai_agent_springboot:${{ github.sha }}


### PR DESCRIPTION
Add CI/CD workflows with GitHub Actions for the Spring Boot agent.

Implementation includes:
- CI workflow for build, test, and Docker image build
- GHCR publish workflow for Docker image publishing on main
- Java 21 and Gradle setup in GitHub Actions

Acceptance Criteria
- CI workflow updated or created
- Docker image build included in CI
- GHCR publish workflow created
- Workflows run successfully on GitHub

Closes #26 