### PR TITLE
[STEP 13] Add Minikube CI job and CI ChatModel stub

### DIFF
--- a/src/main/java/com/anis/agent/config/CiChatModelConfig.java
+++ b/src/main/java/com/anis/agent/config/CiChatModelConfig.java
@@ -1,0 +1,28 @@
+package com.anis.agent.config;
+
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.TokenUsage;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Profile("ci")
+@Configuration
+public class CiChatModelConfig {
+
+    @Bean
+    ChatModel ciChatModel() {
+        return new ChatModel() {
+            @Override
+            public ChatResponse chat(ChatRequest chatRequest) {
+                return ChatResponse.builder()
+                        .aiMessage(AiMessage.from("CI OK"))
+                        .tokenUsage(new TokenUsage(0, 0))
+                        .build();
+            }
+        };
+    }
+}


### PR DESCRIPTION
Add a CI profile and Kubernetes CI job for the AI agent.

Implementation includes:
- CI ChatModel stub returning a deterministic response
- Real Anthropic configuration disabled in CI
- Kubernetes deployment manifest with health probes
- Minikube GitHub Actions job

Acceptance Criteria
- CI profile added
- Fake ChatModel bean added for CI
- Real Anthropic bean disabled in CI
- Kubernetes deployment manifest added
- GitHub Actions Minikube job added
- CI job runs successfully

Closes #30 